### PR TITLE
(fix) Update Repose to use service instead of calling java directly

### DIFF
--- a/centos/7/Dockerfile
+++ b/centos/7/Dockerfile
@@ -16,7 +16,11 @@ VOLUME /etc/repose
 WORKDIR /etc/repose
 USER repose
 
+RUN touch /var/log/repose/current.log
+
+USER root
+
 EXPOSE 8080 9777
 
-CMD java  -Xmx512M -Xms512M -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/tmp/dump-repose.hprof -XX:MaxPermSize=128M -jar /usr/share/repose/repose-valve.jar -c /etc/repose
+CMD service repose-valve start && tail -f /var/log/repose/current.log
 

--- a/ubuntu/1404/Dockerfile
+++ b/ubuntu/1404/Dockerfile
@@ -10,7 +10,11 @@ VOLUME /etc/repose
 WORKDIR /etc/repose
 USER repose
 
+RUN touch /var/log/repose/current.log
+
+USER root
+
 EXPOSE 8080 9777
 
-CMD java  -Xmx512M -Xms512M -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/tmp/dump-repose.hprof -XX:MaxPermSize=128M -jar /usr/share/repose/repose-valve.jar -c /etc/repose
+CMD service repose-valve start && tail -f /var/log/repose/current.log
 


### PR DESCRIPTION
Right now, calling java -jar directly does not allow exec'ing into
the container on carina clusters.  While we are researching the
real reason, the best-practices way to spin up a repose instance
is to use the provided repose-valve service.